### PR TITLE
add --dry-run switch to inhibit registration

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -17,6 +17,7 @@ type consulConfig struct {
 	sslCaCert              string
 	token                  string
 	timeout                int
+	dryRun                 bool
 	heartbeatsBeforeRemove int
 }
 
@@ -32,6 +33,7 @@ func AddCmdFlags(f *flag.FlagSet) {
 	f.StringVar(&config.sslCaCert, "consul-ssl-cacert", "", "")
 	f.StringVar(&config.token, "consul-token", "", "")
 	f.IntVar(&config.timeout, "consul-timeout", 0, "")
+	f.BoolVar(&config.dryRun, "dry-run", false, "")
 	f.IntVar(&config.heartbeatsBeforeRemove, "heartbeats-before-remove", 1, "")
 }
 
@@ -60,6 +62,7 @@ Consul Options:
 				(default: not set)
   --consul-timeout		Set a timeout (in seconds) on requests to Consul
 				(default: 0)
+  --dry-run			Do not register anything in Consul, just log what would have been done.
   --heartbeats-before-remove	Number of times that registration needs to fail
 				before removing task from Consul
 				(default: 1)

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -99,6 +99,11 @@ func (c *Consul) Register(service *registry.Service) {
 		return
 	}
 
+	if c.config.dryRun {
+		log.Info("Dry run, not registering: %s", service.ID)
+		return
+	}
+
 	if _, ok := c.agents[service.Agent]; !ok {
 		// Agent connection not saved. Connect.
 		c.agents[service.Agent] = c.newAgent(service.Agent)

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -100,7 +100,7 @@ func (c *Consul) Register(service *registry.Service) {
 	}
 
 	if c.config.dryRun {
-		log.Info("Dry run, not registering: %s", service.ID)
+		log.Info("Dry run, not registering ", service.ID)
 		return
 	}
 


### PR DESCRIPTION
I wanted to experiment without altering Consul state, so added a switch to do that.  Hopefully others find it useful.