### PR TITLE
Fix bit rot in mesos-go API and Consul dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM alpine:3.5
 
 MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
 
-COPY . /go/src/github.com/CiscoCloud/mesos-consul
-RUN apk add --update go git mercurial \
+COPY . /mesos-consul-source
+RUN apk add --update gcc g++ go git mercurial \
+	&& mkdir -p /go/src/github.com/CiscoCloud \
+	&& cp -a /mesos-consul-source /go/src/github.com/CiscoCloud/mesos-consul \
 	&& cd /go/src/github.com/CiscoCloud/mesos-consul \
 	&& export GOPATH=/go \
 	&& go get \
 	&& go build -o /bin/mesos-consul \
-	&& rm -rf /go \
-	&& apk del --purge go git mercurial
+	&& apk del --purge gcc g++ go git mercurial \
+	&& rm -rf /go
 
 ENTRYPOINT [ "/bin/mesos-consul" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.1
+FROM alpine:3.5
 
 MAINTAINER Chris Aubuchon <Chris.Aubuchon@gmail.com>
 

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -14,7 +14,7 @@ import (
 	"github.com/CiscoCloud/mesos-consul/state"
 
 	consulapi "github.com/hashicorp/consul/api"
-	proto "github.com/mesos/mesos-go/mesosproto"
+	proto "github.com/mesos/mesos-go/api/v0/mesosproto"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/mesos/zk.go
+++ b/mesos/zk.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/mesos/mesos-go/detector"
-	_ "github.com/mesos/mesos-go/detector/zoo"
-	proto "github.com/mesos/mesos-go/mesosproto"
+	"github.com/mesos/mesos-go/api/v0/detector"
+	_ "github.com/mesos/mesos-go/api/v0/detector/zoo"
+	proto "github.com/mesos/mesos-go/api/v0/mesosproto"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/state/state.go
+++ b/state/state.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mesos/mesos-go/upid"
+	"github.com/mesos/mesos-go/api/v0/upid"
 )
 
 // Resources holds resources as defined in the /state.json Mesos HTTP endpoint.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mesos/mesos-go/upid"
+	"github.com/mesos/mesos-go/api/v0/upid"
 	. "github.com/CiscoCloud/mesos-consul/state"
 )
 


### PR DESCRIPTION
mesos-go has moved to a different API, but were kind enough to leave the old one in place, so I've monkey-patched this issue.
Consul API requires Go >=1.7 to build, but Alpine 3.1 had Go 1.3.3; I've updated Dockerfile to point towards Alpine 3.5 with Go 1.7.3.
A certain kernel bug in overlayfs does not allow removing a file created in another layer (cf.  docker/docker#27214). Added a workaround for that.