### PR TITLE
Group services matching the same regex into same group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ package: xcompile
 	done
 
 vendor:
-	glide install --strip-vendor
-	glide update --strip-vendor
+	glide install --strip-vendor --strip-vcs
+	glide update --strip-vendor --strip-vcs
 
 vendor-clean:
 	-rm -rf vendor/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ To build it:
 | `heartbeats-before-remove` | Number of times that registration needs to fail before removing task from Consul. (default: 1)
 | `whitelist`         | Only register services matching the provided regex. Can be specified multitple time
 | `blacklist`         | Does not register services matching the provided regex. Can be specified multitple time
+| `shared-service-name`         | Group services matching the same regex into same group e.g. (KafkaBroker)-.* will register KafkaBroker-0 and KafkaBroker-1 as kafkabroker. Canbe specified multiple times
 | `service-name=<name>`      | Service name of the Mesos hosts
 | `service-tags=<tag>,...` | Comma delimited list of tags to register the Mesos hosts. Mesos hosts will be registered as (leader|master|follower).<tag>.<service>.service.consul
 | `service-id-prefix=<prefix>` | Prefix to use for consul service ids registered by mesos-consul. (default: mesos-consul)

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	FwBlackList     []string
 	TaskTag         []string
 	Separator       string
+	SharedServiceName []string
 
 	// Mesos service name and tags
 	ServiceName     string
@@ -38,6 +39,7 @@ func DefaultConfig() *Config {
 		FwWhiteList:     []string{},
 		FwBlackList:     []string{},
 		TaskTag:         []string{},
+		SharedServiceName: []string{},
 		Separator:       "",
 		ServiceName:     "mesos",
 		ServiceTags:     "",

--- a/main.go
+++ b/main.go
@@ -68,6 +68,10 @@ func parseFlags(args []string) (*config.Config, error) {
 	flags.StringVar(&c.HealthcheckIp, "healthcheck-ip", "127.0.0.1", "")
 	flags.StringVar(&c.HealthcheckPort, "healthcheck-port", "24476", "")
 	flags.Var((funcVar)(func(s string) error {
+		c.SharedServiceName = append(c.SharedServiceName, s)
+		return nil
+	}), "shared-service-name", "")
+	flags.Var((funcVar)(func(s string) error {
 		c.TaskWhiteList = append(c.TaskWhiteList, s)
 		return nil
 	}), "whitelist", "")
@@ -153,6 +157,8 @@ Options:
 				Can be specified multiple times
   --fw-blacklist=<regex>	Do not register services from frameworks matching the provided
 				regex.
+				Can be specified multiple times
+  --shared-service-name=<regex>		Regex to extract common group name from task name e.g. (MesosKafka)-.*
 				Can be specified multiple times
   --task-tag=<pattern:tag>	Tag tasks whose name contains 'pattern' substring (case-insensitive) with given tag.
 				Can be specified multiple times

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -39,6 +39,8 @@ type Mesos struct {
 	ServiceName     string
 	ServiceTags     []string
 	ServiceIdPrefix string
+
+	SharedServiceName []string
 }
 
 func New(c *config.Config) *Mesos {
@@ -58,7 +60,7 @@ func New(c *config.Config) *Mesos {
 		log.WithField("task-tag", c.TaskTag).Fatal(err.Error())
 	}
 
-	m.ServiceName = cleanName(c.ServiceName, c.Separator)
+	m.ServiceName = cleanName(c.ServiceName, c.Separator, c.SharedServiceName)
 
 	m.Registry = consul.New()
 
@@ -83,6 +85,8 @@ func New(c *config.Config) *Mesos {
 	}
 
 	m.ServiceIdPrefix = c.ServiceIdPrefix
+
+	m.SharedServiceName = c.SharedServiceName
 
 	return m
 }

--- a/mesos/register.go
+++ b/mesos/register.go
@@ -104,10 +104,10 @@ func (m *Mesos) registerTask(t *state.Task, agent string) {
 
 	registered := false
 
-	tname := cleanName(t.Name, m.Separator)
+	tname := cleanName(t.Name, m.Separator, m.SharedServiceName)
 	log.Debugf("original TaskName : (%v)", tname)
 	if t.Label("overrideTaskName") != "" {
-		tname = cleanName(t.Label("overrideTaskName"), m.Separator)
+		tname = cleanName(t.Label("overrideTaskName"), m.Separator, m.SharedServiceName)
 		log.Debugf("overrideTaskName to : (%v)", tname)
 	}
 	if !m.TaskPrivilege.Allowed(tname) {

--- a/mesos/util.go
+++ b/mesos/util.go
@@ -19,6 +19,7 @@ func cleanName(name string, separator string, groupPrefixes []string) string {
 		}
 
 		if groups := reg.FindStringSubmatch(_name); len(groups) > 1 {
+			// if matched, the submatch is the second element
 			_name = groups[1]
 			break
 		}

--- a/mesos/util.go
+++ b/mesos/util.go
@@ -9,14 +9,27 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func cleanName(name string, separator string) string {
+func cleanName(name string, separator string, groupPrefixes []string) string {
+	_name := name
+	for _, p := range(groupPrefixes) {
+		reg, err := regexp.Compile(p)
+		if err != nil {
+			log.Warn(err)
+			continue
+		}
+
+		if groups := reg.FindStringSubmatch(_name); len(groups) > 1 {
+			_name = groups[1]
+			break
+		}
+	}
 	reg, err := regexp.Compile("[^\\w-]")
 	if err != nil {
 		log.Warn(err)
-		return name
+		return _name
 	}
 
-	s := reg.ReplaceAllString(name, "-")
+	s := reg.ReplaceAllString(_name, "-")
 
 	return strings.ToLower(strings.Replace(s, "_", separator, -1))
 }

--- a/mesos/util_test.go
+++ b/mesos/util_test.go
@@ -51,3 +51,20 @@ func TestSliceContainsString(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanName(t *testing.T) {
+	for _, tt := range []struct {
+		n string
+		s string
+		g []string
+		r string
+	} {
+		{ "Task_0", "-", []string{}, "task-0"},
+		{ "Task-0", "", []string{"(Task)-.*"}, "task"},
+	} {
+		r := cleanName(tt.n, tt.s, tt.g)
+		if r != tt.r {
+			t.Errorf("cleanName(%s, %s, %v) => %s, want %s", tt.n, tt.s, tt.g, r, tt.r)
+		}
+	}
+}


### PR DESCRIPTION
We sometimes have multiple service named foo-[0..N]. This PR group services matching the same regex into same group e.g. (foo)-.* will register foo-0 and foo-1 under foo